### PR TITLE
Trying to handle unexpected failing when uploading dist files

### DIFF
--- a/scripts/deploy/deploy_dev.js
+++ b/scripts/deploy/deploy_dev.js
@@ -42,7 +42,7 @@ module.exports = function(robot) {
                 await uploadDist('dist', canaryName, fullImage, distribution);
                 msg.send('dist uploaded.');
             } catch (err) {
-                msg.send(err);
+                return msg.send(err);
             }
         }
 

--- a/scripts/deploy/deploy_mirrormedia.js
+++ b/scripts/deploy/deploy_mirrormedia.js
@@ -32,7 +32,7 @@ module.exports = function(robot) {
                 await uploadDist('dist', canaryName, fullImage, 'dist');
                 msg.send('dist uploaded.');
             } catch (err) {
-                msg.send(err);
+                return msg.send(err);
             }
         } else {
             deploymentList.push('tr-projects-rest', 'tr-projects-app');

--- a/scripts/deploy/deploy_readr.js
+++ b/scripts/deploy/deploy_readr.js
@@ -43,7 +43,7 @@ module.exports = function(robot) {
                 await uploadDist('dist', canaryName, fullImage, distribution);
                 msg.send('dist uploaded.');
             } catch (err) {
-                msg.send(err);
+                return msg.send(err);
             }
         }
 


### PR DESCRIPTION
1. stop deploy new image if failed to upload dist
2. add timeout and retry for executing a shell command, this might help to copy files from canary pods
3. add retry for getting canarypod name since the pod might not have been ready right after the scaling (the behavior was observed in the log)